### PR TITLE
refactor code for flipCoin to simplify

### DIFF
--- a/src/CoinFlipper.js
+++ b/src/CoinFlipper.js
@@ -21,17 +21,12 @@ class CoinFlipper extends Component {
     flipCoin() {
         const newCoin = choice(this.props.coins);
         this.setState(st => {
-            let newState = {
-                ...st,
+            return {
                 currCoin: newCoin,
-                numFlips: st.numFlips + 1
-            }
-            if(newCoin.side === "heads") {
-                newState.numHeads +=1;
-            } else {
-                newState.numTails +=1;
-            }
-            return newState;
+                numFlips: st.numFlips + 1,
+                numHeads: st.numHeads + (newCoin.side === "heads" ? 1: 0),
+                numTails: st.numTails + (newCoin.side === "tails" ? 1: 0)             
+            };
         });
     }
     handleClick(e) {


### PR DESCRIPTION
This is some refactoring of code to shorten and simplify the `flipCoin` method.  The `if/else` statement is removed inside the `flipCoin` method.  Instead, a ternary operator is used as a shortcut.  This is done by adding either 1 or 0, based on whether the flip was a heads or tails.  This allows us to return one nice, short object.